### PR TITLE
Set Rendering Mode to Compatability

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -28,3 +28,8 @@ project/assembly_name="godot-state-charts"
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/godot_state_charts/plugin.cfg")
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"


### PR DESCRIPTION
This will allow users to open the test project even when the computer they're using does not run Vulkan.