### PR TITLE
add signals to CompoundState for child state enter and exit

### DIFF
--- a/addons/godot_state_charts/compound_state.gd
+++ b/addons/godot_state_charts/compound_state.gd
@@ -5,6 +5,12 @@
 class_name CompoundState
 extends State
 
+## Called when a child state is entered.
+signal child_state_entered()
+
+## Called when a child state is exited.
+signal child_state_exited()
+
 ## The initial state which should be activated when this state is activated.
 @export_node_path("State") var initial_state:NodePath:
 	get:
@@ -41,7 +47,8 @@ func _state_init():
 		if child is State:
 			var child_as_state:State = child as State
 			child_as_state._state_init()
-
+			child_as_state.state_entered.connect(func(): child_state_entered.emit())
+			child_as_state.state_exited.connect(func(): child_state_exited.emit())
 
 func _state_enter(expect_transition:bool = false):
 	super._state_enter()


### PR DESCRIPTION
Often when dealing with state transitions, I've found that it's convenient to have common logic for all states of a particular category. Currently, you can accomplish this for state logic that runs every frame by using state_processing and state_physics_processing signals emitted by the CompoundState node. But there is no simple way to define behavior that is triggered by *any* *transition* between child states of a CompundState. I feel that this is an essential behavior that is trivial to implement, easy to understand and has little to no impact on performance.