### PR TITLE
add "step" method as an alternative to state_processing and state_physics_processing

### DIFF
--- a/addons/godot_state_charts/compound_state.gd
+++ b/addons/godot_state_charts/compound_state.gd
@@ -53,6 +53,10 @@ func _state_enter(expect_transition:bool = false):
 		else:
 			push_error("No initial state set for state '" + name + "'.")
 
+func _state_step():
+	super._state_step()
+	if _active_state != null:
+		_active_state._state_step()
 
 func _state_save(saved_state:SavedState, child_levels:int = -1):
 	super._state_save(saved_state, child_levels)

--- a/addons/godot_state_charts/parallel_state.gd
+++ b/addons/godot_state_charts/parallel_state.gd
@@ -73,7 +73,11 @@ func _state_exit():
 		child._state_exit()
 	
 	super._state_exit()
-	
+
+func _state_step():
+	super._state_step()
+	for child in _sub_states:
+		child._state_step()
 
 func _state_event(event:StringName) -> bool:
 	if not active:

--- a/addons/godot_state_charts/state.gd
+++ b/addons/godot_state_charts/state.gd
@@ -18,6 +18,9 @@ signal state_processing(delta:float)
 ## Called when the state is physics processing.
 signal state_physics_processing(delta:float)
 
+## Called when the state chart step function is called.
+signal state_stepped()
+
 ## Called when the state is receiving input.
 signal state_input(event:InputEvent)
 
@@ -218,6 +221,9 @@ func _physics_process(delta:float):
 		return
 	state_physics_processing.emit(delta)
 
+## Called when the state chart step function is called.
+func _state_step():
+	state_stepped.emit()
 
 func _input(event:InputEvent):
 	state_input.emit(event)

--- a/addons/godot_state_charts/state_chart.gd
+++ b/addons/godot_state_charts/state_chart.gd
@@ -137,6 +137,10 @@ func _warn_not_active(transition:Transition, source:State):
 func set_expression_property(name:StringName, value) -> void:
 	_expression_properties[name] = value
 
+## Calls the `step` function in all active states. Used for situations where `state_processing` and 
+## `state_physics_processing` don't make sense (e.g. turn-based games, or games with a fixed timestep).
+func step():
+	_state._state_step()
 
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings = []


### PR DESCRIPTION
In many games (such as turn-based games or those with a completely fixed timestep), it does not make sense to use either _processing() nor _physics_processing() to house game logic. This PR allows the user to easily implement their own logic for updating states decoupled from the built-in callbacks.