### PR TITLE
Add reentrace lock to _run_transition

### DIFF
--- a/addons/godot_state_charts/state_chart.gd
+++ b/addons/godot_state_charts/state_chart.gd
@@ -120,7 +120,10 @@ func _run_transition(transition:Transition, source:State):
 	if _transitions_processing_active:
 		_queued_transitions.append({transition : source})
 		return
-
+	
+	# enable the reentrance lock for transition processing
+	_transitions_processing_active = true
+	
 	# we can only transition away from a currently active state
 	# if for some reason the state no longer is active, ignore the transition	
 	_do_run_transition(transition, source)
@@ -131,6 +134,8 @@ func _run_transition(transition:Transition, source:State):
 		var next_transition = next_transition_entry.keys()[0]
 		var next_transition_source = next_transition_entry[next_transition]
 		_do_run_transition(next_transition, next_transition_source)
+	
+	_transitions_processing_active = false
 
 
 ## Runs the transition. Used internally by the state chart, do not call this directly.	


### PR DESCRIPTION
Fixes part of #82. This PR should ensure that all `state_entered` and `state_exited` signals emit in the correct order.

The example from #82 now has this order:
```
[576]: Transition: On Grab from x/Idle to x/Try Grabbing
[576]: exiT: Idle 
[576]: Enter: Try Grabbing
[576]: Transition: To Grabbing from x/Try Grabbing to x/Grabbing Something
[576]: exiT: Try Grabbing
[576]: Enter: Grabbing Something
```

I noticed that most of the logic to handle a queue of events has already been written, but the bool that enables it wasn't being used. Did some quick testing to verify it fixed the out of order problem and that the examples weren't broken, and everything seems fine from what I could tell.

This PR does not fix the transitions being evaluated multiple times, so the "ignored transition for inactive state" warning may still appear.