### PR TITLE
fix StateIsActiveGuard when the target comes from delay transition

### DIFF
--- a/addons/godot_state_charts/state_chart_state.gd
+++ b/addons/godot_state_charts/state_chart_state.gd
@@ -233,6 +233,10 @@ func _process(delta:float) -> void:
 			# print("requesting transition from " + name + " to " + transition_to_send.to.get_concatenated_names() + " now")
 			_chart._run_transition(transition_to_send, self)
 
+			# Re-check transitions for StateIsActiveGuards with states that just changed
+			_chart._property_change_pending = true
+			_chart._run_changes()
+
 
 
 func _handle_transition(_transition:Transition, _source:StateChartState):


### PR DESCRIPTION
Hi!

I've found a small issue with transitions and I found this small change fixed the issue: The `StateIsActiveGuard` does not work when the target state is activated through a delay transition.

In my case, I have states for `Grounded` and `PosJump` and separate `WalkAnimation` and `JumpAnimation` states.
The `PosJump` state has a delayed transition back to `Grounded`.
The `JumpAnimation` state has a transition to `IdleAnimation` with a `StateIsActiveGuard` pointing to `Grounded`.
![imagem](https://github.com/user-attachments/assets/71ab09ee-7b2e-4b00-aedd-08d9d9061916)
![imagem](https://github.com/user-attachments/assets/7f38421b-6c91-4cab-b805-f5a02af71312)
![imagem](https://github.com/user-attachments/assets/84d1b45e-3e34-43ff-bfe2-9c1c92a6071b)

When the transition from `PosJump` to `Grounded` happens, a transition from `JumpAnimation` to `IdleAnimation` should also happen, but **it doesn't**, making the character not change animation.

With the change, whenever a delayed transition happens we check again for any new transitions that should happen because of it, fixing the issue.

Let me know what you think about it, thanks.