### PR TITLE
Improve state chart in platformer demo by handling gravity in Grounded and Airborne states.

### DIFF
--- a/godot_state_charts_examples/platformer/ninja_frog/ninja_frog.tscn
+++ b/godot_state_charts_examples/platformer/ninja_frog/ninja_frog.tscn
@@ -187,7 +187,6 @@ texture_filter = 1
 texture = ExtResource("7_fehuj")
 offset = Vector2(0, -12)
 hframes = 31
-frame = 20
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
 tree_root = SubResource("AnimationNodeStateMachine_ckafx")
@@ -270,8 +269,7 @@ editor_description = "This state is active when the player is airborne but can n
 script = ExtResource("6_vmkuk")
 
 [connection signal="input_event" from="." to="." method="_on_input_event"]
-[connection signal="state_physics_processing" from="StateChart/Root/Grounded" to="." method="_on_grounded_state_physics_processing"]
-[connection signal="state_physics_processing" from="StateChart/Root/Airborne" to="." method="_on_airborne_state_physics_processing"]
+[connection signal="state_physics_processing" from="StateChart/Root/Grounded" to="." method="_on_jump_enabled_state_physics_processing"]
 [connection signal="state_physics_processing" from="StateChart/Root/Airborne/CoyoteJumpEnabled" to="." method="_on_jump_enabled_state_physics_processing"]
 [connection signal="state_physics_processing" from="StateChart/Root/Airborne/DoubleJumpEnabled" to="." method="_on_jump_enabled_state_physics_processing"]
 [connection signal="taken" from="StateChart/Root/Airborne/DoubleJumpEnabled/On Jump" to="." method="_on_double_jump_jump"]

--- a/godot_state_charts_examples/platformer/ninja_frog/ninja_frog.tscn
+++ b/godot_state_charts_examples/platformer/ninja_frog/ninja_frog.tscn
@@ -270,7 +270,8 @@ editor_description = "This state is active when the player is airborne but can n
 script = ExtResource("6_vmkuk")
 
 [connection signal="input_event" from="." to="." method="_on_input_event"]
-[connection signal="state_physics_processing" from="StateChart/Root/Grounded" to="." method="_on_jump_enabled_state_physics_processing"]
+[connection signal="state_physics_processing" from="StateChart/Root/Grounded" to="." method="_on_grounded_state_physics_processing"]
+[connection signal="state_physics_processing" from="StateChart/Root/Airborne" to="." method="_on_airborne_state_physics_processing"]
 [connection signal="state_physics_processing" from="StateChart/Root/Airborne/CoyoteJumpEnabled" to="." method="_on_jump_enabled_state_physics_processing"]
 [connection signal="state_physics_processing" from="StateChart/Root/Airborne/DoubleJumpEnabled" to="." method="_on_jump_enabled_state_physics_processing"]
 [connection signal="taken" from="StateChart/Root/Airborne/DoubleJumpEnabled/On Jump" to="." method="_on_double_jump_jump"]


### PR DESCRIPTION
Hi
It seems it's possible to implement a better state chart in platformer demo.
The history in current implementation is like this:

![s1](https://github.com/user-attachments/assets/0f4ada8f-4154-4996-9f81-e55a265f4480)

It's flooded with same event and because of this the history isn't usable at all. I think we could generally consider event spamming in the history as a sign of the possibility of better state chart out there.
I modified state chart to send event for grounded and airborne only on state switching and history is clean now!

![s2](https://github.com/user-attachments/assets/ae1c63bb-75cb-443e-abfb-6fa803791c6a)
