### PR TITLE
fix: MSBuild warnings

### DIFF
--- a/addons/godot_state_charts/csharp/StateChart.cs
+++ b/addons/godot_state_charts/csharp/StateChart.cs
@@ -100,7 +100,7 @@ namespace GodotStateCharts
             public static readonly StringName EventReceived = "event_received";
         }
         
-        public new class MethodName : Node.MethodName
+        public class MethodName : Node.MethodName
         {
             /// <summary>
             /// Sends an event to the state chart node.

--- a/addons/godot_state_charts/csharp/StateChartDebugger.cs
+++ b/addons/godot_state_charts/csharp/StateChartDebugger.cs
@@ -50,7 +50,7 @@ namespace GodotStateCharts
             Call(MethodName.AddHistoryEntry, text);
         }
         
-        public new class MethodName : Node.MethodName
+        public class MethodName : Node.MethodName
         {
             /// <summary>
             /// Sets the node that the state chart debugger should debug.


### PR DESCRIPTION
Issue: #184

There are MSBuild warnings in the C# wrapper, this fixes them.

![image](https://github.com/user-attachments/assets/ddc75cac-b90a-46bc-9565-8cd92ac9377d)