### PR TITLE
fix: now cannot step when in-active

### DIFF
--- a/addons/godot_state_charts/state_chart_state.gd
+++ b/addons/godot_state_charts/state_chart_state.gd
@@ -236,6 +236,10 @@ func _physics_process(delta:float) -> void:
 
 ## Called when the state chart step function is called.
 func _state_step():
+	if not active:
+		push_warning("The current state " + name + " is not active. ")
+		return
+	
 	state_stepped.emit()
 
 func _input(event:InputEvent):

--- a/addons/godot_state_charts/state_chart_state.gd
+++ b/addons/godot_state_charts/state_chart_state.gd
@@ -237,7 +237,7 @@ func _physics_process(delta:float) -> void:
 ## Called when the state chart step function is called.
 func _state_step():
 	if not active:
-		push_warning("The current state " + name + " is not active. ")
+		push_warning("Cannot do step since the state " + name + " is not active. ")
 		return
 	
 	state_stepped.emit()


### PR DESCRIPTION
Do not execute step when state is inactive. I think this is a proper behaviour since we cannot transit state when the current state is inactive. It is pretty weird that the state can be executed in `step()` but cannot transit state. Please check #186 .