### PR TITLE
Add a property to control whether the transition delay time should be refreshed

### DIFF
--- a/addons/godot_state_charts/state_chart_state.gd
+++ b/addons/godot_state_charts/state_chart_state.gd
@@ -265,7 +265,7 @@ func _process_transitions(trigger_type:StateChart.TriggerType, event:StringName 
 				# print(name +  ": consuming event " + event)
 				# first match wins
 				# if the winning transition is the currently pending transition, we do not replace it
-				if transition != _pending_transition:
+				if transition != _pending_transition or transition.should_refresh_delay_time:
 					_run_transition(transition)
 			
 				# but in any case we return true, because we consumed the event

--- a/addons/godot_state_charts/transition.gd
+++ b/addons/godot_state_charts/transition.gd
@@ -45,6 +45,10 @@ signal taken()
 		_dirty = true
 		update_configuration_warnings()
 
+## Whether to refresh the delay time when the same transition occurs again
+## during the state transition countdown
+@export var should_refresh_delay_time:bool = false
+
 ## A delay in seconds before the transition is taken. Can be 0 in which case
 ## the transition will be taken immediately. The transition will only be taken
 ## if the state is still active when the delay has passed and has never been left.


### PR DESCRIPTION
Some scenarios may require refreshing the state transition delay time. For instance, as shown in tutorial video, when an enemy exits the field of view, the watchman waits 3 seconds before entering idle state. If the enemy comes back into view during this 3-second window, some game scenarios might need to restart the 3-second countdown before transitioning to idle state.